### PR TITLE
fix: Implement intelligent touch passthrough for DivKit overlays

### DIFF
--- a/demo-mobile/src/main/AndroidManifest.xml
+++ b/demo-mobile/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"

--- a/demo-mobile/src/main/assets/div_preview.json
+++ b/demo-mobile/src/main/assets/div_preview.json
@@ -1,23 +1,16 @@
 {
-    "templates":
-      {
-        "name": "DivKitBlock",
-        "settings": {
-          "version": "1.0"
-        }
-      },
   "card": {
-    "log_id": "main_layout",
+    "log_id": "div2_sample_card",
     "states": [
       {
         "state_id": 0,
         "div": {
           "type": "container",
           "width": {
-            "type": "match_parent"
+            "type": "wrap_content"
           },
           "height": {
-            "type": "match_parent"
+            "type": "wrap_content"
           },
           "orientation": "vertical",
           "paddings": {
@@ -98,7 +91,7 @@
                       "items": [
                         {
                           "type": "text",
-                          "text": "City Views!",
+                          "text": "City Dogs!",
                           "font_size": 22,
                           "font_weight": "bold",
                           "margins": {
@@ -156,9 +149,22 @@
                 }
               ]
             }
+          ],
+          "alignment_horizontal": "right",
+          "background": [
+            {
+              "type": "solid",
+              "color": "#ffb800"
+            }
           ]
         }
       }
     ]
+  },
+  "templates": {
+    "name": "DivKitBlock",
+    "settings": {
+      "version": "1.0"
+    }
   }
 }

--- a/demo-tv/build.gradle.kts
+++ b/demo-tv/build.gradle.kts
@@ -37,4 +37,5 @@ android {
 dependencies {
     implementation(libs.androidx.leanback)
     implementation(libs.androidx.core.ktx)
+    implementation("com.github.bumptech.glide:glide:4.16.0")
 }

--- a/demo-tv/src/main/AndroidManifest.xml
+++ b/demo-tv/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />

--- a/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationDetail.kt
+++ b/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationDetail.kt
@@ -40,6 +40,8 @@ class ActivationDetail(
                     configuration = config
                 )
             )
+
+
             divView.setData(detailsData, DivDataTag("SourceSync-ActivationDetails"))
 
             // Add content container to frame layout

--- a/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationPreview.kt
+++ b/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationPreview.kt
@@ -3,6 +3,9 @@ package io.sourcesync.sdk.ui.divkit
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.ContextThemeWrapper
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import com.yandex.div.DivDataTag
 import com.yandex.div.core.Div2Context
@@ -14,6 +17,7 @@ import com.yandex.div2.DivData
 class ActivationPreview
     (context: Context, previewData: DivData, config: DivConfiguration) : FrameLayout(context) {
     private lateinit var divView: Div2View
+    private var onContentClickListener: (() -> Unit)? = null
 
     init {
         initializeView(previewData, config)
@@ -38,9 +42,101 @@ class ActivationPreview
                 configuration = config
             )
         )
+        
         divView.setData(previewData, DivDataTag("SourceSync-ActivationPreview"))
+    
+        
+        // Set up intelligent touch handling
+        setupTouchHandling()
 
-        // Add content container to frame layout
         addView(divView)
+    }
+    
+    private fun setupTouchHandling() {
+        setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    // Check if touch hits actual DivKit content
+                    val hitView = findViewAtPoint(divView, event.x, event.y)
+                    val hasContent = hasContentAtPoint(hitView, event.x, event.y)
+                    
+                    if (hasContent) {
+                        // Trigger content click callback
+                        onContentClickListener?.invoke()
+                        true
+                    } else {
+                        // Pass through to underlying views
+                        false
+                    }
+                }
+                else -> false
+            }
+        }
+    }
+    
+    private fun findViewAtPoint(view: View, x: Float, y: Float): View? {
+        if (!view.isShown || !isPointInView(view, x, y)) {
+            return null
+        }
+        
+        if (view is ViewGroup) {
+            // Check children in reverse order (top to bottom)
+            for (i in view.childCount - 1 downTo 0) {
+                val child = view.getChildAt(i)
+                val childX = x - child.left
+                val childY = y - child.top
+                val hitChild = findViewAtPoint(child, childX, childY)
+                if (hitChild != null) {
+                    return hitChild
+                }
+            }
+        }
+        
+        return view
+    }
+    
+    private fun isPointInView(view: View, x: Float, y: Float): Boolean {
+        return x >= 0 && x < view.width && y >= 0 && y < view.height
+    }
+    
+    private fun hasContentAtPoint(hitView: View?, x: Float, y: Float): Boolean {
+        if (hitView == null || hitView == this || hitView == divView) {
+            return false
+        }
+        
+        // If we hit a child view of DivKit, check if it's actually interactive or visible content
+        return when {
+            // If the view is clickable, it's interactive content
+            hitView.isClickable -> true
+            
+            // If the view has a non-transparent background, it's likely content
+            hitView.background != null -> true
+            
+            // If it's a text view or image view, it's likely content
+            hitView.javaClass.simpleName.contains("Text", ignoreCase = true) -> true
+            hitView.javaClass.simpleName.contains("Image", ignoreCase = true) -> true
+            hitView.javaClass.simpleName.contains("Button", ignoreCase = true) -> true
+            
+            // If the view has specific DivKit class names that indicate content
+            hitView.javaClass.name.contains("div", ignoreCase = true) && 
+            !hitView.javaClass.name.contains("container", ignoreCase = true) -> true
+            
+            else -> false
+        }
+    }
+    
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        ev?.let { event ->
+            val hitView = findViewAtPoint(divView, event.x, event.y)
+            val hasContent = hasContentAtPoint(hitView, event.x, event.y)
+            
+            // Only intercept if there's actual content at the touch point
+            return hasContent
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+    
+    fun setOnContentClickListener(listener: () -> Unit) {
+        this.onContentClickListener = listener
     }
 }

--- a/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationView.kt
+++ b/sourcesync-sdk-ui/src/main/java/io/sourcesync/sdk/ui/divkit/ActivationView.kt
@@ -53,7 +53,7 @@ class ActivationView(private val context: Context) : FrameLayout(context) {
 
         try {
             previewView = ActivationPreview(context, previewData, createDivConfiguration())
-            previewView!!.setOnClickListener { _: View? ->
+            previewView!!.setOnContentClickListener {
                 if (onPreviewClickHandler != null) {
                     previewView!!.visibility = GONE
                     onPreviewClickHandler!!.run()


### PR DESCRIPTION
Add content-aware touch handling to ActivationPreview that only intercepts touches on actual DivKit content, allowing touches on empty areas to pass through to underlying views (e.g., video player controls).

Changes:
- Add intelligent hit testing logic to detect DivKit content vs empty space
- Replace blanket OnClickListener with content-specific callback mechanism
- Implement onInterceptTouchEvent for precise touch event management
- Update demo JSON positioning and add notification permissions

[Screencast_20250711_210144.webm](https://github.com/user-attachments/assets/6a708733-ac02-4d36-bc7e-cb6a1d4a553d)

